### PR TITLE
Add tests for new methods in WP_REST_API_Log_Controller

### DIFF
--- a/tests/test-common.php
+++ b/tests/test-common.php
@@ -88,4 +88,34 @@ class WP_REST_API_Log_Test_Common extends WP_UnitTestCase {
 		$this->assertNotWPError( $response );
 		$this->assertEquals( 200, $response->get_status() );
 	}
+
+	/**
+	 * Test the get_debugging_info method
+	 */
+	function test_get_debugging_info() {
+		$request = new WP_REST_Request( 'GET', '/wp-rest-api-log/entry/1/debugging' );
+		$response = WP_REST_API_Log_Controller::get_debugging_info( $request );
+		$this->assertNotWPError( $response );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	/**
+	 * Test the get_custom_views method
+	 */
+	function test_get_custom_views() {
+		$request = new WP_REST_Request( 'GET', '/wp-rest-api-log/custom-views' );
+		$response = WP_REST_API_Log_Controller::get_custom_views( $request );
+		$this->assertNotWPError( $response );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	/**
+	 * Test the get_custom_modals method
+	 */
+	function test_get_custom_modals() {
+		$request = new WP_REST_Request( 'GET', '/wp-rest-api-log/custom-modals' );
+		$response = WP_REST_API_Log_Controller::get_custom_modals( $request );
+		$this->assertNotWPError( $response );
+		$this->assertEquals( 200, $response->get_status() );
+	}
 }


### PR DESCRIPTION


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dexit/wp-rest-api-log/pull/3?shareId=d1078478-58c4-4b4a-b5d8-8a2b0f08ce1f).